### PR TITLE
Adds initial docker scaffolding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM phusion/passenger-ruby25
+
+# Set correct environment variables
+ENV HOME /root
+
+# Use baseimage-docker's init process
+CMD ["/sbin/my_init"]
+
+# Set the app directory var
+ENV APP_HOME /home/app
+WORKDIR $APP_HOME
+
+# Dependencies
+COPY Gemfile* ./
+RUN bundle install
+
+# Enable passenger and nginx
+RUN rm -f /etc/service/nginx/down
+
+RUN rm /etc/nginx/sites-enabled/default
+ADD webapp.conf /etc/nginx/sites-enabled/webapp.conf
+COPY --chown=app:app . . 
+
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'rails', '~>5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+volumes:
+  postgres:
+
+services:
+  web:
+    build: .
+    volumes:
+      - .:/home/app
+    ports:
+      - 3000:80
+    depends_on:
+      - db
+
+  db:
+    image: postgres:9.6.11-alpine
+    volumes:
+      - postgres:/var/lib/postgresql/data

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,3 @@
+<html>
+  <h1>TBD</h1>
+</html>

--- a/webapp.conf
+++ b/webapp.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+  root /home/app/public;
+
+  passenger_enabled on;
+  passenger_user app;
+
+  passenger_ruby /usr/bin/ruby2.5;
+}


### PR DESCRIPTION
This sets up two containers:
- web (from passenger-ruby)
- db (postgres)

Much of the boilerplate config was taken from the passenger-ruby
[docs][1], some of it may end up obsolete once rails is configured, but
for now this does bring up a working 200 page at `localhost:3000`.

The next increment will be to generate `rails new`, and wire it up with
the existing config.

[1]: https://github.com/phusion/passenger-docker