### PR TITLE
Remove heroku yml file

### DIFF
--- a/.heroku.yml
+++ b/.heroku.yml
@@ -1,3 +1,0 @@
-build:
-  docker:
-    web: Dockerfile


### PR DESCRIPTION
In the previous commit (#3) , I hadn't run `heroku stack:set container` before
deploying, so the successful deploy wasn't actually via Docker. Once doing
that, it identified the heroku config file was misnamed (it should be
`heroku.yml`, not `.heroku.yml`).

Once I renamed the file and re-deployed, the web container crashed due to
permission errors. After invesgiating, it turns out the `sbin/my_init` command
requires root access, which is not provided by Heroku. See
[baseimage-docker issue][1] for details.

Since the actual Heroku deployment is really just a proof-of-concept, I'm going
to remove the config file, and just use the standard Rails deployment there,
while keeping the Docker setup for running locally and a future deploy.

[1]: https://github.com/phusion/baseimage-docker/issues/264